### PR TITLE
Add Wordpress ECS deploy with terraform & packer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.terraform
+.terraform.tfstate.lock.info
+terraform.tfstate
+terraform.tfstate.backup

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+AWS_ACCOUNT=017128164736
+TERRAFORM_SHARED:=terraform/environments/shared
+TERRAFORM_PATH:=terraform/environments/dev
+PACKER_PATH:=packer
+
+requirements:
+ifndef name
+	@echo A name is needed for the environment Ex: make provision name=wordpress
+	exit 1
+endif
+
+ecr-login:
+	eval $(aws ecr get-login --no-include-email)
+
+provision: requirements provision-ecr ecr-login build-image provision-all
+
+destroy: requirements destroy-ecr destroy-all
+
+provision-ecr:
+	cd $(TERRAFORM_SHARED) \
+		&& terraform init \
+		&& terraform apply -var 'name=$(name)'
+
+destroy-ecr:
+	cd $(TERRAFORM_SHARED) \
+		&& terraform init \
+		&& terraform destroy -var 'name=$(name)'
+
+build-image:
+	cd $(PACKER_PATH) \
+		&& packer build \
+		-var 'aws_account=$(AWS_ACCOUNT)' \
+		-var 'name=$(name)' \
+		wordpress.json
+
+provision-all:
+	cd $(TERRAFORM_PATH) \
+		&& terraform init \
+		&& terraform apply \
+		-var 'aws_account=$(AWS_ACCOUNT)' \
+		-var 'name=$(name)'
+
+destroy-all:
+	cd $(TERRAFORM_PATH) \
+		&& terraform init \
+		&& terraform destroy \
+		-var 'aws_account=$(AWS_ACCOUNT)' \
+		-var 'name=$(name)'

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Provision Wordpress environments using Terraform on AWS
-
-This repository contains the resources and rationale about provisioning Wordpress environments on AWS using Terraform.
+This repository contains the resources and rationale about provisioning Wordpress applications on AWS using Terraform & Packer.
 
 # What you have done?
 
+## Short description
+I've used Terraform to provision an ECS cluster and a RDS database in order to run a Docker image built with Packer and configured with Packer's Ansible provisioner.
+
+## How
 I've used Terraform to provision all AWS resources needed to run Wordpress on an ECS cluster. I've used Terraform verified modules when available, but not un-verified or copied (forked) code.
 
-I've added comments on the files. the following docs add more context but basically the same information would be on the project files, I'm adding it also here due the nature of this repository.
+I've added as many docs ass possible on project's files. This README.md add context but the same facts are explained on the files (I'm duplicating them due the nature of this repository).
 
-Despite that this README.md has an [Improvements section] (#share-with-us-any-ideas-you-have-in-mind-to-improve-this-kind-of-infrastructure.), I've added some minor TODO for uncompleted tasks on each component.
+I'm not 100% happy with the results. My first intention was to create a near production ready environment, but all the configurable settings involved soon started to add to much complexity for that goal. 
+
+## Detailed description for the AWS parts
 
 ### VPC
-
 For the VPC I used "terraform-aws-modules/vpc/aws" module, creating the following subnet configuration:
 
 Subnets:
@@ -27,39 +31,129 @@ Using no internet access subnets for `Wordpress` has been discarded as that conf
 - Email sending. 
 
 TODO: 
-
 - [ ] We should make AWS region and AZs configurable.
 
 ### ECR
-
-An ECR repository would be created to push the Wordpress docker images.
+An ECR repository would be created to host our Wordpress docker images.
 
 Configure an ECR policy to keep just the last 20 images. ECR disk usage might become wild with Wordpress images This policy will keep an eye on that.
 
 TODO: 
-
 - [ ] If current's running image gets deleted with this policy we might have problems on auto-scaling.
 
 As Wordpress images are everything but light (probably even > 1GB), I've set an ECR policy to keep just the 20 last images attached to the ECR repository.
 
-# Share with us any ideas you have in mind to improve this kind of infrastructure
+### ECS
+An ECS cluster ready to run our Wordpress jobs, the ECS cluster will use the [ECS linux optimized AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html).
 
-In order to create a "real" Wordpress provisioner there are some details that should be improved:
+Within the ECS cluster a task definition defines the Wordpress application deployment, with the following settings: 
 
-### Adding a troubleshooting instance 
+- Docker Image & Tag to run on the task.
+- Amount of CPU & memory to allocate.
+- Port mappings.
+- Environment variable configuration, (database configuration)
+- EFS volume that contains Wordpress customized files.
 
-In order to provide support while on-call with incidents I would add an troubleshooting instance (probably not an instance but a running docker image) with some tooling like:
+TODO:
+- [ ] Configurable instance type
+- [ ] Configurable min, max & desired capacity.
 
-- [`innotop`](https://github.com/innotop/innotop) for database monitoring. 
-- Wordpress CLI 
-- Custom scripts
+### EFS
+EFS is used to maintain customized Wordpress files uploads, plugins and themes.
 
-### S3 & Cloudfront
+NOTE: 
+Mounting EFS as R+W for every running instance might sound scary but actually performs very well.
 
-On this example we are using an EFS volume to enable "asset sharing" in case of auto-scaling, needed as "uploading" assets is a common task on Wordpress, but that EFS volume adds complexity to the deployment.
+TODO:
+- [ ] Using S3 / Cloudfront for assets & uploads would be a better solution.
+- [ ] We might also mount EFS volumes on an instance responsible for the backups.
+- [ ] Does EFS generalPurpose performance mode meet all use cases requirements?
+- [ ] VPC's default Security Group is used to match ECS cluster's instances but it should have its own, properly grained.
 
 ### RDS
+An RDS (mariadb) instance will be created as wordpress provisioned database
 
+TODO:
+- [ ] There is no database's special params configuration, we are using defaults.
+- [ ] Many RDS options should be configurable: Instance type, Storage size, Maintenance & Backup windows.
+- [ ] Hashicorp vault deployment to store secrets (database password)
+
+# How did you run your project?
+Actually I've been trying to leverage the usual approach of using a bash file or make, etc. to run both build & provisioning. I ran into some open issues like [this](https://github.com/hashicorp/terraform/issues/2789) and [this](https://github.com/hashicorp/terraform/issues/1586) found out that there is nothing better at the moment.
+
+### Requirements
+```
+Terraform v0.12.5
+Packer v1.4.1
+aws-cli v1.16.200
+```
+
+### Usage
+To provision all the infrastructure & resources, run the following command on the repository root:
+```
+make provision name=<wordpress_name>
+```
+
+To destroy all the infrastructure created run:
+
+```
+make destroy name=<wordpress_name>
+```
+
+# What are the components interacting with each other?
+There is an issue described on the following section "What problems did you encounter", related to components interaction:
+
+### Egg & chicken problem with packer builds vs terraform provisioning 
+The ECS task needs a built docker image to run, and you need an ECR repository to hold the Docker image
+
+My first intention was to provision all the infrastructure at once (Including the ECR repository), but ended up spliting the terraform provision in two steps:
+
+- ECR provisioning.
+- Packer docker image & push to the ECR repository.
+- Provision ECS cluster, RDS, etc. 
+
+I'm using the ansible provisioner to "configure" the docker image, but I wouldn't use ansible and I would perform a docker build (alone)
+
+### Wordpress application configuration
+The configuration for Wordpress is provided either by the ansible provisioner or ENV VAR configuration available on the official Wordpress docker image.
+
+### Wordpress application plugins (and uploads)
+This requires a special metion as Wordpress needs to change its own files, when updating plugins, this could be done on the building side (but Wordpress users use the plugin section to perform updates), so I've provided an EFS filesystem for the deployment that keeps Wordpress "customized" files. This component relation is commented later as it does have possibl enhacenments and its suitable for a more advanced strategy.
+ 
+# What problems did you encounter?
+### Terraform complexity
+The whole terraform file structure has quickly become complex to maintain & document due the number of moving parts needed for the project. 
+
+### Egg & chicken problem with packer builds vs terraform provisioning 
+We would need the ECR repository to push the image built on packer and we need the image to provision the ECS task.
+
+# How would you have done things to have the best HA/automated architecture?
+Wordpress has its own tricks (and pains) for HA / automation, taking into account some of the problems described on "What problems did you encounter?", I would add the following things:
+
+### Wordpress plugin & upload file stratetgy 
+As mentioned earlier, on this example I'm using a EFS volumen mounted to all the running instances (as R+W) to provision wordpress files.
+
+This was needed for uploads, plugins, assets, etc files. But more work needs to be done to meet requirements for HA/automation.
+- Using S3 / Cloudfront for assets & uploads would work perfectly.
+- Mounting EFS as R+W for every running instance might sound scary but I've used it performing nice on a similar use case (wordpress perform the uploads on a single request).
+- We might also mount EFS volumes on an instance responsible for the backups. 
+
+### Using ElastiCache to keep PHP sessions
+We would have to use Redis to keep the PHP sessions when running multiple instances of the Wordpress application.
+
+### Use databases on HA
+Primarily use Multi-AZ deployments for the RDS instance, but also the previously mentioned ElastiCache instance.
+
+### Use a different tool than ECS
+Personally I feel more confortable using Kubernetes over ECS, although both share almost the same characteristics / issues for this use case.
+
+# Share with us any ideas you have in mind to improve this kind of infrastructure
+In order to create a "real" Wordpress provisioner there are some details that should be improved:
+
+### Configure Amazon WAF
+Enable [Amazon WAF](https://aws.amazon.com/marketplace/solutions/security/waf-managed-rules) for enhanced protection.
+
+### RDS
 Production RDS environments are supposed to use Multi-AZ configurations, but also this provisioning might include other production related settings like:
 
 - Enable RDS enhanced monitoring
@@ -77,3 +171,19 @@ But also on the mariadb params, starting with the basics:
 - `innodb_log_file_size`
 - `max_connections`
 - `query_cache_size`
+
+### Hashicorp Vault
+Use Hashicorp vault for secrets storing and retrieval within the ECS instance & provisioning.
+
+### Use FPM instead of Apache
+I'm using Apache deployment as it does simplifies my configuration, but FPM has a lower memmory footprint and improved CPU usage.
+
+### Give the option to enable / use NewRelic or any other APM tool
+Probably a little bit complex to provision as it requires API Keys, etc. but It would be a nice tool for application monitoring.
+
+### Adding a troubleshooting instance 
+In order to provide support while on-call with incidents I would add an troubleshooting instance (probably not an instance but a running docker image) with some tooling like:
+
+- [`innotop`](https://github.com/innotop/innotop) for database monitoring. 
+- Wordpress CLI 
+- Custom scripts

--- a/packer/provision.yml
+++ b/packer/provision.yml
@@ -1,0 +1,45 @@
+---
+- name: Provision Python
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Boostrap python
+      raw: test -e /usr/bin/python || (apt-get -y update && apt-get install -y python-minimal)
+
+# Enable mod rewrites on apache. Which is needed to make Wordpress routing wo
+# work properly.
+- name: Configure Apache
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Enable apache rewrites
+      raw: a2enmod rewrite && a2enmod headers
+
+# On this section we are able to configure PHP's deployment settings. Wordpress
+# docker image still have some PHP optimizations and updates some custom
+# settings. But still some settings need some tuning.
+- name: Configure PHP
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Create Custom PHP settings file
+      raw: touch /usr/local/etc/php/conf.d/custom-settings.ini \
+
+    - name: Update PHP upload max file size to a proper value for Wordpress
+      raw: echo "upload_max_filesize = 10M;" >> /usr/local/etc/php/conf.d/custom-settings.ini \
+    - name: Update PHP post max size to a proper value for Wordpress
+      raw: echo "post_max_size=10M;" >> /usr/local/etc/php/conf.d/custom-settings.ini \
+
+    # TODO this has been added as a needed enhacenment, use Redis to store PHP sessions
+    # - name: Set redis to save PHP sessions
+    #   raw: echo "session.save_handler=redis;" >> /usr/local/etc/php/conf.d/custom-settings.ini \
+    # - name: Set redis URL to save PHP sessions
+    #   raw: echo "session.save_path = \"tcp://redis-sessions-master.capsa.svc.cluster.local:6379?auth=MDyMpe4rr4\"" >> /usr/local/etc/php/conf.d/custom-settings.ini
+
+# I was going to configure Wordpress database connection but we can manage that
+# using the following ENV VARS, those ENV VARS update the wp-config.php
+# settings on the docker-entrypoint in the wordrpess Docker Image
+#  - name: Configure Wordpress
+#  hosts: all
+#  gather_facts: no
+#  tasks:

--- a/packer/wordpress.json
+++ b/packer/wordpress.json
@@ -1,0 +1,26 @@
+{
+  "variables": {
+    "aws_account": "",
+    "ecr_url": "dkr.ecr.eu-west-1.amazonaws.com",
+    "name": ""
+  },
+  "builders": [{
+    "type": "docker",
+    "image": "wordpress",
+    "commit": true,
+    "changes": []
+  }],
+
+  "provisioners": [{
+    "type": "ansible",
+    "user": "root",
+    "playbook_file": "provision.yml"
+  }],
+
+  "post-processors": [[ {
+    "type": "docker-tag",
+    "repository": "{{user `aws_account`}}.{{user `ecr_url`}}/{{user `name`}}",
+    "tag": "latest"
+  },
+  "docker-push" ]]
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -4,6 +4,7 @@
 *
 * - VPC
 * - ECR
+* - ECS
 */
 provider "aws" {
   region = "eu-west-1"
@@ -14,7 +15,63 @@ module "vpc" {
   name = var.name
 }
 
-module "ecr" {
-  source = "../../modules/ecr"
+module "elb" {
+  source = "../../modules/elb"
+  name = var.name
+
+  vpc_public_subnets               = module.vpc.public_subnets
+  vpc_allow_http_security_group_id = module.vpc.allow_http_security_group_id
+}
+
+module "rds" {
+  source = "../../modules/rds"
+  name = var.name
+
+  vpc_database_subnets          = module.vpc.database_subnets
+  vpc_default_security_group_id = module.vpc.default_security_group_id
+}
+
+module "efs" {
+  source = "../../modules/efs"
+  name = var.name
+
+  vpc_private_subnets           = module.vpc.private_subnets
+  vpc_default_security_group_id = module.vpc.default_security_group_id
+}
+
+module "ecs-instance-profile" {
+  source = "../../modules/ecs-instance-profile"
   name = var.name
 }
+
+module "ecs" {
+  source = "../../modules/ecs"
+  name = var.name
+
+  vpc_private_subnets           = module.vpc.private_subnets
+  vpc_default_security_group_id = module.vpc.default_security_group_id
+  ecs_instance_profile_name     = module.ecs-instance-profile.name
+}
+
+module "ecs-task-definition" {
+  source = "../../modules/ecs-task-definition"
+  name = var.name
+
+  wordpress_db_host = module.rds.aws_rds_endpoint
+  wordpress_db_name = module.rds.aws_rds_db_name
+  wordpress_db_user = module.rds.aws_rds_db_user
+  wordpress_db_pass = module.rds.aws_rds_db_pass
+
+  ecr_repository_url = "${var.aws_account}.dkr.ecr.eu-west-1.amazonaws.com/${var.name}"
+  docker_image_tag   = "latest"
+}
+
+module "ecs-service" {
+  source = "../../modules/ecs-service"
+  name = var.name
+
+  elb_name                = module.elb.name
+  ecs_cluster_id          = module.ecs.id
+  ecs_task_definition_arn = module.ecs-task-definition.arn
+}
+

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -6,3 +6,11 @@ variable "name" {
   type = "string"
   description = "The base name for all the resources to create"
 }
+
+/*
+* The AWS account to provision resources to
+*/
+variable "aws_account" {
+  type = "string"
+  description = "The AWS account for all the resources to create"
+}

--- a/terraform/environments/shared/main.tf
+++ b/terraform/environments/shared/main.tf
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "ecr" {
+  source = "../../modules/ecr"
+  name = var.name
+}

--- a/terraform/environments/shared/output.tf
+++ b/terraform/environments/shared/output.tf
@@ -1,0 +1,9 @@
+output "arn" {
+  value = "${module.ecr.arn}"
+}
+output "id" {
+  value = "${module.ecr.id}"
+}
+output "url" {
+  value = "${module.ecr.url}"
+}

--- a/terraform/environments/shared/variables.tf
+++ b/terraform/environments/shared/variables.tf
@@ -1,0 +1,7 @@
+/*
+* The ECR repository name
+*/
+variable "name" {
+  type = "string"
+  description = "The base name for all the resources to create"
+}

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -1,5 +1,5 @@
  /*
- * ECR repository created to maintain the Wordpress docker images.
+ * ECR repository created to maintain wordpress docker images.
  */
 resource "aws_ecr_repository" "main" {
   name = var.name
@@ -12,7 +12,9 @@ resource "aws_ecr_repository" "main" {
 * an eye on that.
 *
 * TODO: If the current running image gets deleted using this policy we might
-* have problems on auto-scaling, we might use a unttagged policy rotation.
+* have problems on auto-scaling, possible solutions:
+*
+* - Use an untagged policy?
 */
 resource "aws_ecr_lifecycle_policy" "main" {
   repository = "${aws_ecr_repository.main.name}"

--- a/terraform/modules/ecr/variables.tf
+++ b/terraform/modules/ecr/variables.tf
@@ -1,8 +1,4 @@
-/*
-* The name var flow to all components to create a homogeneus naming for the
-* provisioned resources
-*/
 variable "name" {
   type        = string
-  description = "The ECR's repository name"
+  description = "ECR's repository name"
 }

--- a/terraform/modules/ecs-instance-profile/main.tf
+++ b/terraform/modules/ecs-instance-profile/main.tf
@@ -1,0 +1,45 @@
+/*
+* This IAM Role is tailored with the basic policies for an ECS instance profile
+* to run:
+*
+* - AmazonEC2ContainerServiceforEC2Role
+*   That give basic ECS access permissions for the instance.
+*
+* - CloudWatchLogsFullAccess
+*   That give full access to write (or read) it's own logs for the instance on
+*   CloudWatchLogs.
+*/
+resource "aws_iam_role" "main" {
+  name = var.name
+  path = "/ecs/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["ec2.amazonaws.com"]
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "main" {
+  name = var.name
+  role = aws_iam_role.main.name
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_ec2_role" {
+  role = aws_iam_role.main.id
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_ec2_cloudwatch_role" {
+  role = aws_iam_role.main.id
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
+}

--- a/terraform/modules/ecs-instance-profile/output.tf
+++ b/terraform/modules/ecs-instance-profile/output.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = aws_iam_instance_profile.main.name
+}

--- a/terraform/modules/ecs-instance-profile/variables.tf
+++ b/terraform/modules/ecs-instance-profile/variables.tf
@@ -1,0 +1,8 @@
+/*
+* The name var flow to all components to create a homogeneus naming for the
+* provisioned resources
+*/
+variable "name" {
+  description = "The ECS instance profile name"
+  type        = string
+}

--- a/terraform/modules/ecs-service/main.tf
+++ b/terraform/modules/ecs-service/main.tf
@@ -1,0 +1,30 @@
+/*
+* This ECS service will be responsible of running the wordpress application
+* given the provided task definition.
+*
+* TODO Currently we are using a previously configured ELB, but we might use an
+* ALB.
+*
+* Using binpack with CPU will allow us to place the task on instances with the
+* least available CPU, that will help us to reduce the number of instances.
+*
+* TODO does "spread" placement strategy suit better for us?.
+*
+*/
+resource "aws_ecs_service" "main" {
+  name            = var.name
+  cluster         = var.ecs_cluster_id
+  task_definition = var.ecs_task_definition_arn
+  desired_count   = 2
+
+  ordered_placement_strategy {
+    type  = "binpack"
+    field = "cpu"
+  }
+
+  load_balancer {
+    elb_name = var.elb_name
+    container_name = var.name
+    container_port = 80
+  }
+}

--- a/terraform/modules/ecs-service/variables.tf
+++ b/terraform/modules/ecs-service/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  type        = string
+  description = "ECS service name"
+}
+
+variable "ecs_cluster_id" {
+  type        = string
+  description = "The previously provisioned main ECS cluster ID"
+}
+
+variable "ecs_task_definition_arn" {
+  type        = string
+  description = "The previously provisioned ECS Task Definition ARN"
+}
+
+variable "elb_name" {
+  type        = string
+  description = "The previously provisioned main ELB Name"
+}

--- a/terraform/modules/ecs-task-definition/main.tf
+++ b/terraform/modules/ecs-task-definition/main.tf
@@ -1,0 +1,39 @@
+/*
+* This task definition defines the wordpress application deployment, It does
+* set the following settings for the ECS cluster:
+*
+* - Docker Image & Tag to run on the task.
+* - Amount of CPU & memory to allocate.
+* - Port mappings.
+* - Environment variable configuration.
+*
+* All that information might be find on the service.json file
+*
+* It does also configures the EFS volume that contains Wordpress customized
+* files.
+*/
+data "template_file" "wordpress-task-definition" {
+  template = file("${path.module}/service.json")
+
+  vars = {
+    name = "${var.name}"
+
+    repository = "${var.ecr_repository_url}"
+    tag        = "${var.docker_image_tag}"
+
+    wordpress_db_host = "${var.wordpress_db_host}"
+    wordpress_db_name = "${var.wordpress_db_name}"
+    wordpress_db_user = "${var.wordpress_db_user}"
+    wordpress_db_pass = "${var.wordpress_db_pass}"
+  }
+}
+
+resource "aws_ecs_task_definition" "main" {
+  family                = "service"
+  container_definitions = data.template_file.wordpress-task-definition.rendered
+
+  volume {
+    name      = "service-storage"
+    host_path = "/ecs/service-storage"
+  }
+}

--- a/terraform/modules/ecs-task-definition/output.tf
+++ b/terraform/modules/ecs-task-definition/output.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  description = "The main AWS Task Definition ARN"
+  value       = aws_ecs_task_definition.main.arn
+}

--- a/terraform/modules/ecs-task-definition/service.json
+++ b/terraform/modules/ecs-task-definition/service.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "${name}",
+    "image": "${repository}:${tag}",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "environment": [
+      { "name": "WORDPRESS_DB_HOST",     "value": "${wordpress_db_host}" },
+      { "name": "WORDPRESS_DB_NAME",     "value": "${wordpress_db_name}" },
+      { "name": "WORDPRESS_DB_USER",     "value": "${wordpress_db_user}" },
+      { "name": "WORDPRESS_DB_PASSWORD", "value": "${wordpress_db_pass}" }
+    ],
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ]
+  }
+]

--- a/terraform/modules/ecs-task-definition/variables.tf
+++ b/terraform/modules/ecs-task-definition/variables.tf
@@ -1,0 +1,34 @@
+variable "name" {
+  type        = string
+  description = "RDS database name"
+}
+
+variable "wordpress_db_host" {
+  type        = string
+  description = "Previously deployed RDS host"
+}
+
+variable "wordpress_db_name" {
+  type        = string
+  description = "Previously deployed RDS database name"
+}
+
+variable "wordpress_db_user" {
+  type        = string
+  description = "Previously deployed RDS database user name"
+}
+
+variable "wordpress_db_pass" {
+  type        = string
+  description = "Previously deployed RDS database password"
+}
+
+variable "ecr_repository_url" {
+  type        = string
+  description = "Previously deployed ECR repository URL"
+}
+
+variable "docker_image_tag" {
+  type        = string
+  description = "Docker container image tag to run"
+}

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,0 +1,56 @@
+/*
+* ECS cluster definition
+*
+* The AMI selected for the cluster would be the AWS ECS optimized AMI.
+*
+* More info about this AMI on:
+* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+*/
+resource "aws_ecs_cluster" "main" {
+  name = var.name
+}
+
+data "aws_ami" "amazon_linux_ecs" {
+  most_recent = true
+  owners = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-*-amazon-ecs-optimized"]
+  }
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+}
+
+/*
+* ECS cluster autoscalling group, many options for the auto-scaling group should
+* be configurable.
+*
+* TODO VPC default security group shouldn't be used for the deployment a better
+* tailored Security Group should be created, for the instances.
+* TODO Instance type, min, max & desired capacity should be configurable.
+*/
+module "ecs" {
+  source  = "terraform-aws-modules/autoscaling/aws"
+  version = "~> 3.0"
+
+  name = var.name
+  lc_name = var.name
+
+  image_id             = data.aws_ami.amazon_linux_ecs.id
+  instance_type        = "t2.micro"
+  security_groups      = [var.vpc_default_security_group_id]
+  iam_instance_profile = var.ecs_instance_profile_name
+
+  user_data = "#!/bin/bash\necho ECS_CLUSTER='${var.name}' >> /etc/ecs/ecs.config"
+
+  asg_name                  = var.name
+  vpc_zone_identifier       = var.vpc_private_subnets
+  health_check_type         = "EC2"
+  min_size                  = 1
+  max_size                  = 1
+  desired_capacity          = 1
+  wait_for_capacity_timeout = 0
+}

--- a/terraform/modules/ecs/output.tf
+++ b/terraform/modules/ecs/output.tf
@@ -1,0 +1,4 @@
+output "id" {
+  description = "The ID of the ECS Cluster"
+  value = "${aws_ecs_cluster.main.id}"
+}

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -1,0 +1,23 @@
+/*
+* The name var flow to all components to create a homogeneus naming for the
+* provisioned resources
+*/
+variable "name" {
+  type        = string
+  description = "The ECS cluster name"
+}
+
+variable "vpc_default_security_group_id" {
+  type        = string
+  description = "The previously provisioned VPC default's SG ID"
+}
+
+variable "vpc_private_subnets" {
+  type        =  list(string)
+  description = "The previously provisioned VPC private subnets"
+}
+
+variable "ecs_instance_profile_name" {
+  type        = string
+  description = "The previously provisioned ECS IAM Role Name"
+}

--- a/terraform/modules/efs/main.tf
+++ b/terraform/modules/efs/main.tf
@@ -1,0 +1,29 @@
+/*
+* This EFS is used to maintain customized Wordpress files uploads, plugins and
+* themes.
+*
+* Mounting EFS as R+W for every running instance might sound scary but actually
+* performs very well.
+*
+* TODO Using S3 / Cloudfront for assets & uploads would be a better solution.
+* TODO We might also mount EFS volumes on an instance responsible for the backups.
+* TODO Does EFS generalPurpose performance mode meet all use cases requirements?
+* TODO VPC's default Security Group is used to match ECS cluster's instances but
+* it should have its own, properly grained.
+*/
+resource "aws_efs_file_system" "main" {
+  performance_mode = "generalPurpose"
+
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_efs_mount_target" "main" {
+  file_system_id = "${aws_efs_file_system.main.id}"
+
+  count     = "${length(var.vpc_private_subnets)}"
+  subnet_id = "${element(var.vpc_private_subnets, count.index)}"
+
+  security_groups = ["${var.vpc_default_security_group_id}"]
+}

--- a/terraform/modules/efs/variables.tf
+++ b/terraform/modules/efs/variables.tf
@@ -1,0 +1,19 @@
+/*
+* The name var flow to all components to create a homogeneus naming for the
+* provisioned resources
+*/
+variable "name" {
+  type        = string
+  description = "The EFS file system name"
+}
+
+variable "vpc_private_subnets" {
+  type        = list(string)
+  description = "The previously provisioned VPC private subnets"
+}
+
+variable "vpc_default_security_group_id" {
+  type        = string
+  description = "The previously provisioned VPC default's SG ID"
+}
+

--- a/terraform/modules/elb/main.tf
+++ b/terraform/modules/elb/main.tf
@@ -1,0 +1,37 @@
+/*
+* ELB definition to provide access from "the internet" for the running ECS
+* wordpress tasks.
+*
+* TODO Should this be an ALB instead of an ELB.
+*
+*/
+module "elb" {
+  source = "terraform-aws-modules/elb/aws"
+
+  name = var.name
+
+  subnets         = var.vpc_public_subnets
+  security_groups = [var.vpc_allow_http_security_group_id]
+  internal        = false
+
+  listener = [
+    {
+      instance_port     = "80"
+      instance_protocol = "HTTP"
+      lb_port           = "80"
+      lb_protocol       = "HTTP"
+    },
+  ]
+
+  health_check = {
+      target              = "HTTP:80/"
+      interval            = 30
+      healthy_threshold   = 2
+      unhealthy_threshold = 2
+      timeout             = 5
+  }
+
+  tags = {
+    Name = var.name
+  }
+}

--- a/terraform/modules/elb/output.tf
+++ b/terraform/modules/elb/output.tf
@@ -1,0 +1,4 @@
+output "name" {
+  description = "The ELB Name"
+  value       = module.elb.this_elb_name
+}

--- a/terraform/modules/elb/variables.tf
+++ b/terraform/modules/elb/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  type        = string
+  description = "The ELB name"
+}
+
+variable "vpc_allow_http_security_group_id" {
+  type        = string
+  description = "The previously provisioned VPC Allow HTTP Security Group ID"
+}
+
+variable "vpc_public_subnets" {
+  type        =  list(string)
+  description = "The previously provisioned VPC public subnets"
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,65 @@
+/*
+* RDS definition that will hold Wordpress need database, a compliant MariaDB
+* database will be created for that purpose.
+*
+* TODO there is no database's special params configuration, we are using
+* defaults.
+* TODO Many RDS options should be configurable:
+* - Instance type.
+* - Storage size.
+* - Maintenance & Backup windows.
+* TODO Hashicorp vault deployment to store secrets (database password)
+*/
+resource "random_string" "password" {
+  length            = 20
+  special           = true
+  min_special       = 5
+  override_special  = "!#$%^&*()-_=+[]{}<>:?"
+  keepers           = {
+    pass_version  = 1
+  }
+}
+
+module "rds" {
+  source  = "terraform-aws-modules/rds/aws"
+  version = "~> 2.0"
+
+  identifier = var.name
+
+  engine            = "mariadb"
+  engine_version    = "10.3.13"
+  instance_class    = "db.t2.micro"
+  allocated_storage = 5
+
+  major_engine_version = "10.3"
+
+  # TODO Remove this setting, I'm using it on testing to avoid:
+  # https://github.com/terraform-providers/terraform-provider-aws/issues/4597
+  # But should be disabled on production (also on deployment) provisioning
+  skip_final_snapshot = true
+
+  parameter_group_name = "default.mariadb10.3"
+  family               = "mariadb10.3"
+
+  name     = var.name
+  username = var.name
+  password = random_string.password.result
+  port     = "3306"
+
+  vpc_security_group_ids = [var.vpc_default_security_group_id]
+  subnet_ids             =  var.vpc_database_subnets
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  parameters = [
+    {
+      name = "character_set_client"
+      value = "utf8"
+    },
+    {
+      name = "character_set_server"
+      value = "utf8"
+    }
+  ]
+}

--- a/terraform/modules/rds/output.tf
+++ b/terraform/modules/rds/output.tf
@@ -1,0 +1,19 @@
+output "aws_rds_endpoint" {
+  description = "RDS connection endpoint"
+  value       = module.rds.this_db_instance_endpoint
+}
+
+output "aws_rds_db_name" {
+  description = "RDS database name"
+  value       = module.rds.this_db_instance_name
+}
+
+output "aws_rds_db_user" {
+  description = "RDS database user"
+  value       = module.rds.this_db_instance_username
+}
+
+output "aws_rds_db_pass" {
+  description = "RDS database pass"
+  value       = module.rds.this_db_instance_password
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  type        = string
+  description = "RDS database name"
+}
+
+variable "vpc_database_subnets" {
+  type        = list(string)
+  description = "The previously provisioned VPC database subnets"
+}
+
+variable "vpc_default_security_group_id" {
+  type        = string
+  description = "The previously provisioned VPC default's SG ID"
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -42,3 +42,23 @@ module "vpc" {
     Name = var.name
   }
 }
+
+resource "aws_security_group" "allow_http" {
+  name        = "allow_http"
+  description = "Allow HTTP inbound traffic"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/modules/vpc/output.tf
+++ b/terraform/modules/vpc/output.tf
@@ -3,6 +3,11 @@ output "vpc_id" {
   value       = module.vpc.vpc_id
 }
 
+output "default_security_group_id" {
+  description = "The ID for the default Security Group"
+  value       = module.vpc.default_security_group_id
+}
+
 output "private_subnets" {
   description = "List of IDs of private subnets"
   value       = module.vpc.private_subnets
@@ -17,3 +22,9 @@ output "database_subnets" {
   description = "List of IDs of database subnets"
   value       = module.vpc.database_subnets
 }
+
+output "allow_http_security_group_id" {
+  description = "The ID for the default Security Group that allow HTTP traffic"
+  value       = aws_security_group.allow_http.id
+}
+


### PR DESCRIPTION
This PR adds the Wordpress deployment on ECS using Terraform to provision AWS infrastructure & packer to build & configure the Wordpress image.